### PR TITLE
Fix SoundCloud mobile

### DIFF
--- a/adservers.txt
+++ b/adservers.txt
@@ -5243,7 +5243,6 @@
 0.0.0.0 api.mixpanel.com
 0.0.0.0 api.mobileapptracking.com
 0.0.0.0 api.mobile.cnzz.com
-0.0.0.0 api-mobi.soundcloud.com
 0.0.0.0 api.mobojoy.baidu.com
 0.0.0.0 api.mobpalm.com
 0.0.0.0 api.mobpowertech.com


### PR DESCRIPTION
Without `api-mobi.soundcloud.com` the mobile SoundCloud page does not work correctly. For instance, user search does not work.