### PR TITLE
Create .gitattributes to add file colours

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+adservers.txt linguist-detectable linguist-language=hosts
+CoinMiner.txt linguist-detectable linguist-language=hosts
+facebook.txt linguist-detectable linguist-language=hosts


### PR DESCRIPTION
A GitHub Linguist update earlier today, combined with me studying more of the poorly documented Gitattributes syntax, makes me certain that Hosts file syntax coloring now works correctly around 4 months behind schedule, resulting in files specified as hosts files in `.gitattributes` showing entries in blue/blue-purple and comments in grey.
![image](https://github.com/anudeepND/blacklist/assets/22780683/f25c6e50-98f6-4cf7-824e-c2907dc97c18)